### PR TITLE
fix .needs_migration? method not found error

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -3,7 +3,7 @@ require 'config/environment'
 
 use Rack::Static, :urls => ['/css'], :root => 'public' # Rack fix allows seeing the css folder.
 
-if defined?(ActiveRecord::Migrator) && ActiveRecord::Migrator.needs_migration?
+if defined?(ActiveRecord::Migrator) && ActiveRecord::Base.connection.migration_context.needs_migration?
   raise 'Migrations are pending run `rake db:migrate` to resolve the issue.'
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,7 @@ require 'rack/test'
 require 'capybara/rspec'
 require 'capybara/dsl'
 
-if defined?(ActiveRecord::Migrator) && ActiveRecord::Migrator.needs_migration?
+if defined?(ActiveRecord::Migrator) && ActiveRecord::Base.connection.migration_context.needs_migration?
   raise 'Migrations are pending run `rake db:migrate SINATRA_ENV=test` to resolve the issue.'
 end
 


### PR DESCRIPTION
Looks like some of the methods have been rearranged in the ActiveRecord::Migrator:Class so `ActiveRecord::Migrator` should be changed to `ActiveRecord::Base.connection.migration_context` so the `#needs_migration?` method will work.

Reference:
- [Stack overflow](https://stackoverflow.com/questions/50790649/nomethoderror-undefined-method-needs-migration-for-activerecordmigratorcl)
- [Can not run db:migrate, NoMethodError: undefined method `migrate' for ActiveRecord::Migrator #522](https://github.com/influitive/apartment/issues/522)
- [Support ActiveRecord-5.2 migration context #523](https://github.com/influitive/apartment/pull/523)